### PR TITLE
fix build strings

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   # recipe-lint failed in v0 if mpi was undefined; keep the same defaulting behavior
   mpi: ${{ mpi or "nompi" }}
   # prioritize nompi via build number
-  build_number: ${{ 100 if mpi == "nompi" else 0 }}
+  build_number: ${{ 101 if mpi == "nompi" else 1 }}
   mpi_prefix: ${{ "mpi_" + mpi if mpi != "nompi" else "nompi" }}
 
 package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,7 +28,7 @@ build:
   # `tempest-extremes * mpi_*` for any mpi
   # `tempest-extremes * nompi_*` for no mpi
 
-  string: ${{ mpi_prefix }}_h${{ PKG_HASH }}_${{ build_number }}
+  string: ${{ mpi_prefix }}_h${{ hash }}_${{ build_number }}
 
 requirements:
   build:


### PR DESCRIPTION
This project is relying on some conventions that work with `conda-build` but not with schema v1 and `rattler-build`. As a result, the package hash is not actually getting included in build strings:

<img width="1030" height="507" alt="Screenshot 2025-12-29 at 11 25 33 PM" src="https://github.com/user-attachments/assets/fa9b1e65-3591-4c19-bf5c-cc48fa8f539e" />

ref: https://anaconda.org/channels/conda-forge/packages/tempest-extremes/files

This fixes that.

## Notes for Reviewers

I noticed this because I recently started on my first transition to `rattler-build` and worked through similar issues there: https://github.com/conda-forge/lightgbm-feedstock/pull/80#discussion_r2648963552

Thanks for your time and consideration.

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.